### PR TITLE
Fix position issue in sys vc, eg. cancel button in UIImagePickerControll...

### DIFF
--- a/UINavigationItem+iOS7Spacing.m
+++ b/UINavigationItem+iOS7Spacing.m
@@ -53,7 +53,13 @@
 {
     if ([self isIOS7] && rightBarButtonItem) {
         [self mk_setRightBarButtonItem:nil];
-        [self mk_setRightBarButtonItems:@[[self spacer], rightBarButtonItem]];
+
+        // Fix position issue in system vc, eg. cancel button in UIImagePickerController
+        if (rightBarButtonItem.customView) {
+            [self mk_setRightBarButtonItems:@[[self spacer], rightBarButtonItem]];
+        } else {
+            [self mk_setRightBarButtonItem:rightBarButtonItem];
+        }
     } else {
         if ([self isIOS7]) {
             [self mk_setRightBarButtonItems:nil];


### PR DESCRIPTION
Cancel button in UIImagePickerController will have a unneeded spacer when the category added into project. It seems that the spacer is only needed when bar button item set via custom view.
